### PR TITLE
Pass $PUBLIC_IP_ADDRESS to worker for queueHost

### DIFF
--- a/roles/arch_3/vars/main.yml
+++ b/roles/arch_3/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 pancancer_arch3_version: 1.0.3
 queueName: seqware
-queueHost: localhost
+queueHost: "{{ lookup('env','PUBLIC_IP_ADDRESS') }}"
 queueUser: queue_user
 queuePassword: queue
 hostUser: ubuntu


### PR DESCRIPTION
Worker node should use _this_ (the launcher) machine's $PUBLIC_IP_ADDRESS as the queueHost
