### PR TITLE
Feature/more clean azure

### DIFF
--- a/roles/storage/lvm/tasks/install.yml
+++ b/roles/storage/lvm/tasks/install.yml
@@ -33,19 +33,19 @@
   ignore_errors: yes  
   when: azure
 
-- name: Storage | WTF, Unmount the temporary drive first
+- name: Storage | Unmount the temporary drive first. Mystery, needs to be done twice on G5 instance
   sudo: true
   shell: umount /mnt
   ignore_errors: yes  
   when: azure
 
-- name: Storage | WTF, Wipe them out. All of them. Again.
+- name: Storage | Wipe them out. All of them. Mystery, needs to be done twice on G5 instance
   sudo: true
   shell: dd if=/dev/zero of=/dev/sdb bs=512 count=1
   ignore_errors: yes  
   when: azure
 
-- name: Storage | WTF, Remove existing temporary drive (Azure). Again
+- name: Storage | Remove existing temporary drive (Azure). Mystery, needs to be done twice on G5 instance
   sudo: true
   shell: parted --script /dev/sdb rm 1
   ignore_errors: yes  

--- a/roles/storage/lvm/tasks/install.yml
+++ b/roles/storage/lvm/tasks/install.yml
@@ -15,6 +15,16 @@
     - ecryptfs-utils 
     - xfsprogs
 
+- name: Storage | Unmount the temporary drive first
+  sudo: true
+  shell: sudo umount /mnt || true
+  when: azure
+
+- name: Storage | Wipe them out. All of them. 
+  sudo: true
+  shell: sudo dd if=/dev/zero of=/dev/sdb bs=512 count=1 || true
+  when: azure
+
 - name: Storage | Remove existing temporary drive (Azure)
   sudo: true
   shell: sudo parted --script /dev/sdb rm 1 || true

--- a/roles/storage/lvm/tasks/install.yml
+++ b/roles/storage/lvm/tasks/install.yml
@@ -33,6 +33,25 @@
   ignore_errors: yes  
   when: azure
 
+- name: Storage | WTF, Unmount the temporary drive first
+  sudo: true
+  shell: umount /mnt
+  ignore_errors: yes  
+  when: azure
+
+- name: Storage | WTF, Wipe them out. All of them. Again.
+  sudo: true
+  shell: dd if=/dev/zero of=/dev/sdb bs=512 count=1
+  ignore_errors: yes  
+  when: azure
+
+- name: Storage | WTF, Remove existing temporary drive (Azure). Again
+  sudo: true
+  shell: parted --script /dev/sdb rm 1
+  ignore_errors: yes  
+  when: azure
+
+
 - name: Storage | Create a volume group white listed devices
   lvg: vg=volume_group pvs={{ lvm_device_whitelist }} state=present vg_options=
   register: lvm_volume_created

--- a/roles/storage/lvm/tasks/install.yml
+++ b/roles/storage/lvm/tasks/install.yml
@@ -17,17 +17,20 @@
 
 - name: Storage | Unmount the temporary drive first
   sudo: true
-  shell: sudo umount /mnt || true
+  shell: umount /mnt
+  ignore_errors: yes  
   when: azure
 
 - name: Storage | Wipe them out. All of them. 
   sudo: true
-  shell: sudo dd if=/dev/zero of=/dev/sdb bs=512 count=1 || true
+  shell: dd if=/dev/zero of=/dev/sdb bs=512 count=1
+  ignore_errors: yes  
   when: azure
 
 - name: Storage | Remove existing temporary drive (Azure)
   sudo: true
-  shell: sudo parted --script /dev/sdb rm 1 || true
+  shell: parted --script /dev/sdb rm 1
+  ignore_errors: yes  
   when: azure
 
 - name: Storage | Create a volume group white listed devices


### PR DESCRIPTION
This annoying commit handles an odd problem with the Azure G5 instances. 
For some bizarre reason which doesn't apply to the D14 instances, we need to unmount and format the drives twice. 
