### PR TITLE
These tasks are no longer needed.

### DIFF
--- a/roles/seqware-container/tasks/main.yml
+++ b/roles/seqware-container/tasks/main.yml
@@ -10,16 +10,16 @@
   pip: name=docker-py state=present version=1.1.0
 
 # This file is used for installing a seqware container
-- name: Install seqware_whitestar Docker container for pancancer
-  docker:
-    image: pancancer/seqware_whitestar_pancancer:{{ seqware_version }}
-    pull: missing
+#- name: Install seqware_whitestar Docker container for pancancer
+#  docker:
+#    image: pancancer/seqware_whitestar_pancancer:{{ seqware_version }}
+#    pull: missing
 
 # This file is used for installing a seqware container
-- name: Install seqware_whitestar Docker container
-  docker:
-    image: seqware/seqware_whitestar:{{ seqware_version }}
-    pull: missing
+#- name: Install seqware_whitestar Docker container
+#  docker:
+#    image: seqware/seqware_whitestar:{{ seqware_version }}
+#    pull: missing
 
 - name: Create workflows directory
   sudo: yes


### PR DESCRIPTION
Installing Seqware containers from the main playbook is no longer needed. Params sent into container-host-bag can be used to specify for each workflow which Seqware container to use.

Pancancer CLI config contains this data:
See: https://github.com/ICGC-TCGA-PanCancer/cli/blob/d81f0c4e3f35dd8f905b1482ddef847c89f7de7d/config/workflowlist.json

Also, see here:
https://github.com/ICGC-TCGA-PanCancer/container-host-bag/blob/8c6c10e489af583cd54fedeed21ef89b7020bada/roles/containers/tasks/main.yml
to see how this data is used.
